### PR TITLE
Hyperlink DOIs to preferred resolver & broaden regex

### DIFF
--- a/doi.psgi
+++ b/doi.psgi
@@ -73,10 +73,10 @@ my $aref2mods = aREF2MODS->new(fixes => [], aref2json => $aref2json);
 Catmandu::Plack::unAPI->new(
     # Get DOI data via RDF Linked Open Data
     query => sub {
-        if ($_[0] !~ qr{^(doi:|https?://dx\.doi\.org/)?10\.\d+/\S+$}) {
+        if ($_[0] !~ qr{^(doi:|https?://(dx\.)?doi\.org/)?10\.\d+/\S+$}) {
             return 'invalid DOI'
         }
-        my $url = "http://dx.doi.org/".$_[0];
+        my $url = "https://doi.org/".$_[0];
         my $rdf = importer('RDF', url => $url)->first;
         $rdf->{_url} = $url if $rdf;
         return $rdf;


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the code that generates new DOI links.

- [ ] Also, the `10.` part of the reg-ex could be updated to [CrossRef's recommendation](https://www.crossref.org/blog/dois-and-matching-regular-expressions/).

Cheers!